### PR TITLE
fix: feed の削除ボタンを動作するように修正

### DIFF
--- a/Controller/RssReadersController.php
+++ b/Controller/RssReadersController.php
@@ -177,7 +177,7 @@ class RssReadersController extends RssReadersAppController {
 			return $this->throwBadRequest();
 		}
 
-		$this->Announcement->deleteRssReader($this->request->data);
+		$this->RssReader->deleteRssReader($this->request->data);
 		$this->redirect(NetCommonsUrl::backToPageUrl());
 	}
 


### PR DESCRIPTION
## やったこと
- Announcement ではなく、RssReader を呼び出すようにした

## なぜやったか
- Announcement を呼び出していたため、null になっていて、deleteRssReader() ができない状態になっていた
