### PR TITLE
fix: rssが日本時間で出力されている場合に表示がおかしくなる。

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.1', '7.2', '7.3', '7.4' ]
-        mysql: [ '5.7', '8.0' ]
+        php: [ '7.4' ]
+        mysql: ['8.0' ]
 
     env:
         NC3_BUILD_DIR: "/opt/nc3"

--- a/Model/RssReaderItem.php
+++ b/Model/RssReaderItem.php
@@ -208,6 +208,8 @@ class RssReaderItem extends RssReadersAppModel {
 		foreach ($items as $item) {
 
 			$date = new DateTime(Hash::get($item, $dateKey, 'now'));
+			$date->setTimezone(new DateTimeZone('UTC'));
+
 			$summary = Hash::get($item, $summaryKey, '');
 			if (is_array($summary) && isset($summary['@'])) {
 				$summary = $summary['@'];


### PR DESCRIPTION
下記のような場合、10/3 2:01で表示されてしまう。
```
<title>[事前登録制] 10/28 (火) Mendeley 利用講習会</title>
<pubDate>Thu, 02 Oct 2025 17:01:58 +0900</pubDate>
```
https://www.kyokyo-u.ac.jp/library/rss.xml